### PR TITLE
VirusTotalv3: Refactoring - Changed data pathing for scan results

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ action\_result\.data\.\*\.attributes\.categories\.alphaMountain\.ai | string |
 action\_result\.data\.\*\.attributes\.categories\.sophos | string | 
 action\_result\.data\.\*\.attributes\.creation\_date | numeric | 
 action\_result\.data\.\*\.attributes\.jarm | string | 
+action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.vendor | string |
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.category | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_name | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.method | string | 
@@ -173,6 +174,7 @@ action\_result\.data\.\*\.attributes\.authentihash | string |
 action\_result\.data\.\*\.attributes\.creation\_date | numeric | 
 action\_result\.data\.\*\.attributes\.first\_submission\_date | numeric | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_date | numeric | 
+action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.vendor | string |
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.category | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_name | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_update | string | 
@@ -303,6 +305,7 @@ action\_result\.data\.\*\.attributes\.crowdsourced\_context\.\*\.source | string
 action\_result\.data\.\*\.attributes\.crowdsourced\_context\.\*\.timestamp | numeric | 
 action\_result\.data\.\*\.attributes\.crowdsourced\_context\.\*\.title | string | 
 action\_result\.data\.\*\.attributes\.jarm | string | 
+action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.vendor | string |
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.category | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_name | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.method | string | 
@@ -375,6 +378,7 @@ action\_result\.data\.\*\.attributes\.categories\.Dr\.Web | string |
 action\_result\.data\.\*\.attributes\.categories\.alphaMountain\.ai | string | 
 action\_result\.data\.\*\.attributes\.first\_submission\_date | numeric | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_date | numeric | 
+action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.vendor | string |
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.category | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_name | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.method | string | 
@@ -439,6 +443,7 @@ action\_result\.data\.\*\.attributes\.categories\.\* | string |
 action\_result\.data\.\*\.attributes\.categories\.Dr\.Web | string | 
 action\_result\.data\.\*\.attributes\.first\_submission\_date | numeric | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_date | numeric | 
+action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.vendor | string |
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.category | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_name | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.method | string | 
@@ -558,6 +563,7 @@ action\_result\.data\.\*\.attributes\.first\_submission\_date | numeric |
 action\_result\.data\.\*\.attributes\.html\_info\.iframes\.\*\.attributes\.\* | string | 
 action\_result\.data\.\*\.attributes\.html\_info\.scripts\.\*\.attributes\.src | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_date | numeric | 
+action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.vendor | string |
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.category | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_name | string | 
 action\_result\.data\.\*\.attributes\.last\_analysis\_results\.\*\.engine\_update | string | 

--- a/virustotalv3.json
+++ b/virustotalv3.json
@@ -11,7 +11,7 @@
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2021-2022 Splunk Inc.",
-    "app_version": "1.2.14",
+    "app_version": "1.2.15",
     "utctime_updated": "2022-01-25T21:04:52.000000Z",
     "package_name": "phantom_virustotalv3",
     "main_module": "virustotalv3_connector.py",
@@ -155,6 +155,16 @@
                     "data_type": "string",
                     "example_values": [
                         "27d40d40d29d40d1dc42d43d00041d4689ee210389f4f6b4b5b1b93f92252d"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.attributes.last_analysis_results.*.vendor",
+                    "data_type": "string",
+                    "example_values": [
+                        "Symantec",
+                        "CrowdStrike",
+                        "SentinelOne",
+                        "Microsoft"
                     ]
                 },
                 {
@@ -865,6 +875,16 @@
                     "data_type": "numeric",
                     "example_values": [
                         1613635130
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.attributes.last_analysis_results.*.vendor",
+                    "data_type": "string",
+                    "example_values": [
+                        "Symantec",
+                        "CrowdStrike",
+                        "SentinelOne",
+                        "Microsoft"
                     ]
                 },
                 {
@@ -1645,6 +1665,16 @@
                     ]
                 },
                 {
+                    "data_path": "action_result.data.*.attributes.last_analysis_results.*.vendor",
+                    "data_type": "string",
+                    "example_values": [
+                        "Symantec",
+                        "CrowdStrike",
+                        "SentinelOne",
+                        "Microsoft"
+                    ]
+                },
+                {
                     "data_path": "action_result.data.*.attributes.last_analysis_results.*.category",
                     "data_type": "string",
                     "example_values": [
@@ -2088,6 +2118,16 @@
                     ]
                 },
                 {
+                    "data_path": "action_result.data.*.attributes.last_analysis_results.*.vendor",
+                    "data_type": "string",
+                    "example_values": [
+                        "Symantec",
+                        "CrowdStrike",
+                        "SentinelOne",
+                        "Microsoft"
+                    ]
+                },
+                {
                     "data_path": "action_result.data.*.attributes.last_analysis_results.*.category",
                     "data_type": "string",
                     "example_values": [
@@ -2449,6 +2489,16 @@
                     "data_type": "numeric",
                     "example_values": [
                         1618399455
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.attributes.last_analysis_results.*.vendor",
+                    "data_type": "string",
+                    "example_values": [
+                        "Symantec",
+                        "CrowdStrike",
+                        "SentinelOne",
+                        "Microsoft"
                     ]
                 },
                 {
@@ -3209,6 +3259,16 @@
                     "data_type": "numeric",
                     "example_values": [
                         1613635130
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.attributes.last_analysis_results.*.vendor",
+                    "data_type": "string",
+                    "example_values": [
+                        "Symantec",
+                        "CrowdStrike",
+                        "SentinelOne",
+                        "Microsoft"
                     ]
                 },
                 {

--- a/virustotalv3_connector.py
+++ b/virustotalv3_connector.py
@@ -442,6 +442,14 @@ class VirustotalV3Connector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR,
                                             VIRUSTOTAL_ERROR_MSG_OBJECT_QUERIED, object_name=object_name, object_value=object_value)
 
+        # if last_analysis_results exists, reorganize to support standard data path format of
+        # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
+        if json_resp['data'].get('attributes', {}).get('last_analysis_results'):
+            last_analysis_results = []
+            for vendor, results in json_resp['data']['attributes']['last_analysis_results'].items():
+                last_analysis_results.append({"vendor": vendor, **results})
+            json_resp['data']['attributes']['last_analysis_results'] = last_analysis_results
+
         # add the data
         action_result.add_data(json_resp['data'])
 
@@ -475,6 +483,13 @@ class VirustotalV3Connector(BaseConnector):
         if 'data' not in json_resp:
             return action_result.set_status(phantom.APP_ERROR, VIRUSTOTAL_ERROR_MSG_OBJECT_QUERIED, object_name='Hash', object_value=hash)
 
+        # if last_analysis_results exists, reorganize to support standard data path format of
+        # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
+        if json_resp['data'].get('attributes', {}).get('last_analysis_results'):
+            last_analysis_results = []
+            for vendor, results in json_resp['data']['attributes']['last_analysis_results'].items():
+                last_analysis_results.append({"vendor": vendor, **results})
+            json_resp['data']['attributes']['last_analysis_results'] = last_analysis_results
         action_result.add_data(json_resp['data'])
 
         response = json_resp['data']['attributes']
@@ -553,6 +568,14 @@ class VirustotalV3Connector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR,
                                             VIRUSTOTAL_ERROR_MSG_OBJECT_QUERIED, object_name=object_name, object_value=object_value)
 
+        # if last_analysis_results exists, reorganize to support standard data path format of
+        # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
+        if json_resp['data'].get('attributes', {}).get('last_analysis_results'):
+            last_analysis_results = []
+            for vendor, results in json_resp['data']['attributes']['last_analysis_results'].items():
+                last_analysis_results.append({"vendor": vendor, **results})
+            json_resp['data']['attributes']['last_analysis_results'] = last_analysis_results
+
         # add the data
         action_result.add_data(json_resp['data'])
 
@@ -589,6 +612,14 @@ class VirustotalV3Connector(BaseConnector):
 
         if 'data' not in json_resp:
             return action_result.set_status(phantom.APP_ERROR, VIRUSTOTAL_ERROR_MSG_OBJECT_QUERIED, object_name='URL', object_value=param['url'])
+
+        # if last_analysis_results exists, reorganize to support standard data path format of
+        # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
+        if json_resp['data'].get('attributes', {}).get('last_analysis_results'):
+            last_analysis_results = []
+            for vendor, results in json_resp['data']['attributes']['last_analysis_results'].items():
+                last_analysis_results.append({"vendor": vendor, **results})
+            json_resp['data']['attributes']['last_analysis_results'] = last_analysis_results
 
         action_result.add_data(json_resp['data'])
 
@@ -640,6 +671,15 @@ class VirustotalV3Connector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, VIRUSTOTAL_ERROR_MSG_OBJECT_QUERIED, object_name='URL', object_value=param['url'])
 
         item_summary = action_result.set_summary({})
+
+        # if last_analysis_results exists, reorganize to support standard data path format of
+        # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
+        if json_resp['data'].get('attributes', {}).get('last_analysis_results'):
+            last_analysis_results = []
+            for vendor, results in json_resp['data']['attributes']['last_analysis_results'].items():
+                last_analysis_results.append({"vendor": vendor, **results})
+            json_resp['data']['attributes']['last_analysis_results'] = last_analysis_results
+
         # add the data
         action_result.add_data(json_resp['data'])
 
@@ -718,6 +758,15 @@ class VirustotalV3Connector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, VIRUSTOTAL_ERROR_MSG_OBJECT_QUERIED, object_name='Hash', object_value=file_hash)
 
         item_summary = action_result.set_summary({})
+
+        # if last_analysis_results exists, reorganize to support standard data path format of
+        # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
+        if json_resp['data'].get('attributes', {}).get('last_analysis_results'):
+            last_analysis_results = []
+            for vendor, results in json_resp['data']['attributes']['last_analysis_results'].items():
+                last_analysis_results.append({"vendor": vendor, **results})
+            json_resp['data']['attributes']['last_analysis_results'] = last_analysis_results
+
         # add the data
         action_result.add_data(json_resp['data'])
 


### PR DESCRIPTION
Changed data pathing for scan results


Please ensure your pull request (PR) adheres to the following guidelines:

- Please refer to our contributing documentation for any questions on submitting a pull request, link: [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md)

## Pull Request Checklist

#### Please check if your PR fulfills the following requirements:
- [x] Testing of all the changes has been performed (for bug fixes / features)
- [x] The readme.html has been reviewed and added / updated if needed (for bug fixes / features)
- [x] Use the following format for the PR description: `<App Name>: <PR Type> - <PR Description>`
- [x] Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.
- [x] Verify all checks are passing.
- [x] Do NOT use the `next` branch of the forked repo. Create separate feature branch for raising the PR.
- [x] Do NOT submit updates to dependencies unless it fixes an issue.
## Pull Request Type

#### Please check the type of change your PR introduces:
- [ ] New App
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation
- [ ] Other (please describe): 

## Release Notes (REQUIRED)
- Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.

  - Modified python on ip reputation, domain reputation, file reputation, url reputation, detonate url, and detonate file to organize vendor results as a list rather than a dictionary with a new key called "vendor". Allows all vendor results to be accessed with a single data path: `action_result.data.*.attributes.last_analysis_results`
  - Modified app json to reflect new key for the 6 actions


## What is the current behavior? (OPTIONAL)
- Describe the current behavior that you are modifying.
  - Current behavior requires playbook authors to know which vendor they want to access. This is problematic because VirusTotal vendors are always changing, along with their products that are used for VirusTotal.

## What is the new behavior? (OPTIONAL)
- Describe the behavior or changes that are being added by this PR.
  - The json result from the reputation or detonation action is modified so that the last_analysis_results will be a list of dictionaries, rather than a single dictionary with one key per vendor

## Other information (OPTIONAL)
- Any other information that is important to this PR such as screenshots of how the component looks before and after the change.

## Pay close attention to (OPTIONAL)
- Any specific code change or test case points which must be addressed/reviewed at the time of GA release.

## Screenshots (if relevant)
- Previous Behavior
![Previous Behavior](https://user-images.githubusercontent.com/69353980/157742422-c8fc49f9-6bf4-49d7-9156-65bf8d118f40.png)
- New Behavior
![New Behavior](https://user-images.githubusercontent.com/69353980/157742472-ee288912-9284-4ea7-b198-e715e216db8e.png)


---
Thanks for contributing!
