### PR TITLE
fix: make sandbox_verdict optional for file reputation

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Make FileReputationOutput.attributes.sandbox_verdicts optional, to fix a failing test.

--- a/src/models/outputs/file_reputation/file.py
+++ b/src/models/outputs/file_reputation/file.py
@@ -50,7 +50,7 @@ class FileAttributes(ActionOutput):
     known_distributors: Optional[KnownFileDistributors]
     type_tag: str
     md5: str = OutputField(cef_types=["md5"])
-    sandbox_verdicts: FileSandboxVerdicts
+    sandbox_verdicts: Optional[FileSandboxVerdicts]
     sha256: str = OutputField(cef_types=["sha256"])
     last_submission_date: int = OutputField(cef_types=["timestamp"])
     trid: Optional[list[TrID]]

--- a/uv.lock
+++ b/uv.lock
@@ -920,7 +920,7 @@ wheels = [
 
 [[package]]
 name = "virustotalv3"
-version = "2.0.0"
+version = "2.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "splunk-soar-sdk", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- Make `FileReputationOutput.attributes.sandbox_verdicts` optional, to fix a failing test.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
