### PR TITLE
fix: send URL as form data in detonate_url

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* fix detonate_url to send URL as form data instead of JSON

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * fix detonate_url to send URL as form data instead of JSON
+* fix polling in detonate actions being broken by response caching

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -21,4 +21,4 @@ from . import models
 from . import app
 from . import utils
 
-__ALL__ = [app, models, utils]
+__all__ = ["app", "models", "utils"]

--- a/src/app.py
+++ b/src/app.py
@@ -235,7 +235,15 @@ def _make_request(
     else:
         client = asset.get_client()
 
-    if asset.cache_reputation_checks and asset.cache_expiration_interval > 0:
+    # Skip caching for analyses/ endpoints since their responses change as
+    # analysis progresses — caching them breaks polling in detonate actions.
+    use_cache = (
+        asset.cache_reputation_checks
+        and asset.cache_expiration_interval > 0
+        and not endpoint.startswith("analyses/")
+    )
+
+    if use_cache:
         saved_cache = asset.cache_state.get("vt_cache")
         datacache = DataCache(
             asset.cache_expiration_interval, asset.cache_size, saved_cache
@@ -263,7 +271,7 @@ def _make_request(
         )
 
     resp_json = response.json()
-    if asset.cache_reputation_checks and asset.cache_expiration_interval > 0:
+    if use_cache:
         # we're no longer going to store failed responses in the cache
         datacache.add(cache_key, ("success", resp_json))
         asset.cache_state["vt_cache"] = datacache.cache

--- a/src/app.py
+++ b/src/app.py
@@ -885,7 +885,7 @@ def poll_for_result(
                 undetected=attributes.get("stats", {}).get("undetected", 0),
             )
 
-            return resp_json, summary
+            return resp_json["data"], summary
 
         num_attempts -= 1
         time.sleep(60)

--- a/src/app.py
+++ b/src/app.py
@@ -106,7 +106,6 @@ class Asset(BaseAsset):
     def get_client(self) -> httpx.Client:
         headers = {
             "x-apikey": self.apikey,
-            "Content-Type": "application/json",
         }
         return httpx.Client(
             base_url="https://www.virustotal.com/api/v3/",
@@ -231,7 +230,6 @@ def _make_request(
             timeout=asset.timeout,
             headers={
                 "x-apikey": asset.apikey,
-                "Content-Type": "application/json",
             },
         )
     else:
@@ -780,7 +778,7 @@ def detonate_url(
     resp_json = _make_request(asset, "GET", f"urls/{url_id}", raise_for_status=False)
 
     if resp_json.get("error", {}).get("code") in PASS_ERROR_CODE.values():
-        resp_json = _make_request(asset, "POST", "urls", json={"url": params.url})
+        resp_json = _make_request(asset, "POST", "urls", data={"url": params.url})
         if not (scan_id := resp_json.get("data", {}).get("id")):
             raise ActionFailure(f"No scan ID found for URL {params.url}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "virustotalv3"
-version = "2.0.7"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "splunk-soar-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary
- Fix `detonate_url` to POST URLs as form data (`data=`) instead of JSON (`json=`) to match VirusTotal API expectations (SOARHELP-6507)
- Remove hardcoded `Content-Type: application/json` from HTTP client headers so `httpx` can automatically set the correct content type based on payload (`json=`, `data=`, `files=`)
- Fix polling in detonate actions: the response cache was caching in-progress analysis responses from `/analyses/{scan_id}`, so subsequent poll attempts returned stale "queued" results instead of making fresh API calls — causing detonations to always time out for new URLs/files

🤖 Generated with [Claude Code](https://claude.com/claude-code)