### PR TITLE
fix: bound downloads and refresh detonation analyses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.0
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -2024,9 +2024,9 @@ summary.total_objects_successful | numeric | | 1 |
 Load a URL to Virus Total and retrieve analysis results
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
-<b>detonate url</b> will send a URL to Virus Total for analysis. Virus Total, however, takes an indefinite amount of time to complete this scan. This action will poll for the results for a short amount of time. If it cannot get the finished results in this amount of time, it will fail and in the summary it will return the <b>scan id</b>. This should be used with the <b>get report</b> action to finish the scan.<br>If you attempt to upload a URL which has already been scanned by Virus Total, it will not rescan the URL but instead will return those already existing results.<br/>Wait time parameter will be considered only if the given URL has not been previously submitted to the VirusTotal Server. For the wait time parameter, the priority will be given to the action parameter over the asset configuration parameter.
+<b>detonate url</b> sends a URL to VirusTotal for a fresh analysis and polls for the result. A URL already known to VirusTotal is explicitly reanalyzed rather than returning its prior verdict. This action can change remote analysis state and is not read only. If polling does not finish in the configured time, the action fails with the scan ID in its summary; use <b>get report</b> to continue polling it.<br/>Wait time parameter takes precedence over the asset configuration value.
 
 #### Action Parameters
 
@@ -2670,9 +2670,9 @@ summary.total_objects_successful | numeric | | 1 |
 Upload a file to Virus Total and retrieve the analysis results
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
-<b>detonate file</b> will send a file to Virus Total for analysis. Virus Total, however, takes an indefinite amount of time to complete this scan. This action will poll for the results for a short amount of time. If it cannot get the finished results in this amount of time, it will fail and in the summary it will return the <b>scan id</b>. This should be used with the <b>get report</b> action to finish the scan.<br>If you attempt to upload a file which has already been scanned by Virus Total, it will not rescan the file but instead will return those already existing results.<br/>Wait time parameter will be considered only if the given file has not been previously submitted to the VirusTotal Server. For the wait time parameter, the priority will be given to the action parameter over the asset configuration parameter.
+<b>detonate file</b> uploads an unknown file to VirusTotal or explicitly requests a fresh analysis when the file is already known, then polls for the result. This action can change remote analysis state and is not read only. If polling does not finish in the configured time, the action fails with the scan ID in its summary; use <b>get report</b> to continue polling it.<br/>Wait time parameter takes precedence over the asset configuration value.
 
 #### Action Parameters
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **cache_reputation_checks** | optional | boolean | Cache virustotal reputation checks |
 **cache_expiration_interval** | optional | numeric | Number of seconds until cached reputation checks expire. Any other value than positive integer will disable caching (Default: 3600 seconds) |
 **cache_size** | optional | numeric | Maximum number of entries in cache. Values of zero or less will not limit size and decimal value will be converted to floor value (Default: 1000) |
+**max_file_download_size_mib** | optional | numeric | Maximum size in MiB for a file downloaded by the get file action (Default: 100 MiB) |
 
 ### Supported Actions
 
@@ -1472,6 +1473,8 @@ Downloads a file from VirusTotal and adds it to the vault
 
 Type: **investigate** <br>
 Read only: **True**
+
+<b>get file</b> streams the requested file into the vault and verifies its requested hash before it is added. Downloads larger than the asset's maximum file download size are rejected; the default limit is 100 MiB.
 
 #### Action Parameters
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Refresh development tooling.
+* Limit streamed get file downloads to the configured maximum size.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Limit streamed get file downloads to the configured maximum size.
+* Request fresh analyses when detonating known URLs and files.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Refresh development tooling.

--- a/src/app.py
+++ b/src/app.py
@@ -237,7 +237,12 @@ def _check_rate_limit(asset, count=1) -> None:
 
 
 def _make_request(
-    asset: Asset, method: str, endpoint: str, raise_for_status: bool = True, **kwargs
+    asset: Asset,
+    method: str,
+    endpoint: str,
+    raise_for_status: bool = True,
+    cacheable: bool = True,
+    **kwargs,
 ) -> dict:
     if endpoint.startswith(("http://", "https://")):
         endpoint = validate_upload_url(endpoint)
@@ -250,10 +255,12 @@ def _make_request(
     else:
         client = asset.get_client()
 
-    # Skip caching for analyses/ endpoints since their responses change as
-    # analysis progresses — caching them breaks polling in detonate actions.
+    # Only cache ordinary reputation GETs. Detonation/reanalysis callers opt out,
+    # and mutating requests must never be satisfied from or stored in the cache.
     use_cache = (
-        asset.cache_reputation_checks
+        cacheable
+        and method.upper() == "GET"
+        and asset.cache_reputation_checks
         and asset.cache_expiration_interval > 0
         and not endpoint.startswith("analyses/")
     )
@@ -814,7 +821,8 @@ def detonate_url_view(outputs: list[DetonateUrlOutput]) -> dict:
 @app.action(
     description="Load a URL to Virus Total and retrieve analysis results",
     action_type="investigate",
-    verbose="<b>detonate url</b> will send a URL to Virus Total for analysis. Virus Total, however, takes an indefinite amount of time to complete this scan. This action will poll for the results for a short amount of time. If it cannot get the finished results in this amount of time, it will fail and in the summary it will return the <b>scan id</b>. This should be used with the <b>get report</b> action to finish the scan.<br>If you attempt to upload a URL which has already been scanned by Virus Total, it will not rescan the URL but instead will return those already existing results.<br/>Wait time parameter will be considered only if the given URL has not been previously submitted to the VirusTotal Server. For the wait time parameter, the priority will be given to the action parameter over the asset configuration parameter.",
+    verbose="<b>detonate url</b> sends a URL to VirusTotal for a fresh analysis and polls for the result. A URL already known to VirusTotal is explicitly reanalyzed rather than returning its prior verdict. This action can change remote analysis state and is not read only. If polling does not finish in the configured time, the action fails with the scan ID in its summary; use <b>get report</b> to continue polling it.<br/>Wait time parameter takes precedence over the asset configuration value.",
+    read_only=False,
     summary_type=DetonateSummary,
     view_handler=detonate_url_view,
 )
@@ -822,54 +830,29 @@ def detonate_url(
     params: DetonateUrlParams, soar: SOARClient, asset: Asset
 ) -> DetonateUrlOutput:
     url_id = base64.urlsafe_b64encode(params.url.encode()).decode().strip("=")
-    resp_json = _make_request(asset, "GET", f"urls/{url_id}", raise_for_status=False)
+    resp_json = _make_request(
+        asset, "GET", f"urls/{url_id}", raise_for_status=False, cacheable=False
+    )
 
     if resp_json.get("error", {}).get("code") in PASS_ERROR_CODE.values():
         resp_json = _make_request(asset, "POST", "urls", data={"url": params.url})
-        if not (scan_id := resp_json.get("data", {}).get("id")):
-            raise ActionFailure(f"No scan ID found for URL {params.url}")
+    else:
+        if not resp_json.get("data"):
+            raise ActionFailure(f"No data found for URL {params.url}")
+        resp_json = _make_request(asset, "POST", f"urls/{url_id}/analyse")
 
-        output, summary = poll_for_result(
-            scan_id,
-            asset.poll_interval,
-            params.wait_time or asset.waiting_time,
-            asset,
-        )
-        soar.set_summary(summary)
-        soar.set_message(summary.get_message())
-        return DetonateUrlOutput(**output)
+    if not (scan_id := resp_json.get("data", {}).get("id")):
+        raise ActionFailure(f"No scan ID found for URL {params.url}")
 
-    if not (data := resp_json.get("data")):
-        raise ActionFailure(f"No data found for URL {params.url}")
-
-    sanitized_data = sanitize_url_object(sanitize_key_names(data))
-    logger.debug(f"Sanitized data: {sanitized_data}")
-
-    # if last_analysis_results exists, reorganize to support standard data path format of
-    # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
-    attributes = sanitized_data.get("attributes", {})
-    if "last_analysis_results" in attributes:
-        last_analysis_results = [
-            {"vendor": vendor, **results}
-            for vendor, results in attributes["last_analysis_results"].items()
-        ]
-        sanitized_data["attributes"]["last_analysis_results"] = last_analysis_results
-
-    new_scan_id = f"u-{sanitized_data['id']}-{attributes['last_submission_date']}"
-    if "last_analysis_stats" in attributes:
-        summary = DetonateSummary(
-            scan_id=new_scan_id,
-            harmless=attributes["last_analysis_stats"]["harmless"],
-            malicious=attributes["last_analysis_stats"]["malicious"],
-            suspicious=attributes["last_analysis_stats"]["suspicious"],
-            timeout=attributes["last_analysis_stats"]["timeout"],
-            undetected=attributes["last_analysis_stats"]["undetected"],
-        )
-        soar.set_summary(summary)
-        soar.set_message(summary.get_message())
-
-    logger.debug(f"Sanitized data: {sanitized_data}")
-    return DetonateUrlOutput(**sanitized_data, scan_id=new_scan_id)
+    output, summary = poll_for_result(
+        scan_id,
+        asset.poll_interval,
+        params.wait_time or asset.waiting_time,
+        asset,
+    )
+    soar.set_summary(summary)
+    soar.set_message(summary.get_message())
+    return DetonateUrlOutput(**output)
 
 
 class DetonateFileParams(Params):
@@ -907,7 +890,10 @@ def poll_for_result(
     num_attempts = poll_interval
     while num_attempts > 0:
         resp_json = _make_request(
-            asset, "GET", f"analyses/{encode_api_path_segment(scan_id)}"
+            asset,
+            "GET",
+            f"analyses/{encode_api_path_segment(scan_id)}",
+            cacheable=False,
         )
         if isinstance(resp_json, dict):
             resp_json = sanitize_key_names(resp_json)
@@ -959,7 +945,8 @@ def detonate_file_view(outputs: list[DetonateFileOutput]) -> dict:
 @app.action(
     description="Upload a file to Virus Total and retrieve the analysis results",
     action_type="investigate",
-    verbose="<b>detonate file</b> will send a file to Virus Total for analysis. Virus Total, however, takes an indefinite amount of time to complete this scan. This action will poll for the results for a short amount of time. If it cannot get the finished results in this amount of time, it will fail and in the summary it will return the <b>scan id</b>. This should be used with the <b>get report</b> action to finish the scan.<br>If you attempt to upload a file which has already been scanned by Virus Total, it will not rescan the file but instead will return those already existing results.<br/>Wait time parameter will be considered only if the given file has not been previously submitted to the VirusTotal Server. For the wait time parameter, the priority will be given to the action parameter over the asset configuration parameter.",
+    verbose="<b>detonate file</b> uploads an unknown file to VirusTotal or explicitly requests a fresh analysis when the file is already known, then polls for the result. This action can change remote analysis state and is not read only. If polling does not finish in the configured time, the action fails with the scan ID in its summary; use <b>get report</b> to continue polling it.<br/>Wait time parameter takes precedence over the asset configuration value.",
+    read_only=False,
     summary_type=DetonateSummary,
     view_handler=detonate_file_view,
 )
@@ -980,7 +967,11 @@ def detonate_file(
     file_hash = attachment.hash
 
     resp_json = _make_request(
-        asset, "GET", f"files/{file_hash}", raise_for_status=False
+        asset,
+        "GET",
+        f"files/{file_hash}",
+        raise_for_status=False,
+        cacheable=False,
     )
 
     if resp_json.get("error", {}).get("code") in PASS_ERROR_CODE.values():
@@ -1008,43 +999,18 @@ def detonate_file(
 
         return DetonateFileOutput(**output, vault_id=vault_id, scan_id=scan_id)
 
-    if not (data := resp_json.get("data")):
+    if not resp_json.get("data"):
         raise ActionFailure(f"No data found for file {file_hash}")
+    resp_json = _make_request(asset, "POST", f"files/{file_hash}/analyse")
+    if not (scan_id := resp_json.get("data", {}).get("id")):
+        raise ActionFailure(f"No scan ID found for file {file_hash}")
 
-    sanitized_data = sanitize_key_names(data)
-    logger.debug(f"Sanitized data: {sanitized_data}")
-
-    # if last_analysis_results exists, reorganize to support standard data path format of
-    # data.*.attributes.last_analysis_results.*.vendor since vendors are always changing
-    attributes = sanitized_data.get("attributes", {})
-    if "last_analysis_results" in attributes:
-        last_analysis_results = [
-            {"vendor": vendor, **results}
-            for vendor, results in attributes["last_analysis_results"].items()
-        ]
-        sanitized_data["attributes"]["last_analysis_results"] = last_analysis_results
-
-    if "last_analysis_date" in attributes:
-        new_scan_id = f"{attributes['md5']}:{attributes['last_analysis_date']}"
-    else:
-        new_scan_id = f"{attributes['md5']}:{attributes['last_submission_date']}"
-
-    new_scan_id = base64.b64encode(new_scan_id.encode()).decode()
-
-    if "last_analysis_stats" in attributes:
-        summary = DetonateSummary(
-            scan_id=new_scan_id,
-            harmless=attributes["last_analysis_stats"]["harmless"],
-            malicious=attributes["last_analysis_stats"]["malicious"],
-            suspicious=attributes["last_analysis_stats"]["suspicious"],
-            timeout=attributes["last_analysis_stats"]["timeout"],
-            undetected=attributes["last_analysis_stats"]["undetected"],
-        )
-        soar.set_summary(summary)
-        soar.set_message(summary.get_message())
-
-    logger.debug(f"Sanitized data: {sanitized_data}")
-    return DetonateFileOutput(**sanitized_data, vault_id=vault_id, scan_id=new_scan_id)
+    output, summary = poll_for_result(
+        scan_id, asset.poll_interval, params.wait_time or asset.waiting_time, asset
+    )
+    soar.set_summary(summary)
+    soar.set_message(summary.get_message())
+    return DetonateFileOutput(**output, vault_id=vault_id, scan_id=scan_id)
 
 
 class GetReportParams(Params):

--- a/src/app.py
+++ b/src/app.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import httpx
+from pathlib import Path
+import shutil
+import tempfile
 
 from soar_sdk.abstract import SOARClient
 from soar_sdk.action_results import ActionOutput, OutputField, PermissiveActionOutput
@@ -57,8 +60,8 @@ from utils import (
     encode_api_path_segment,
     sanitize_key_names,
     sanitize_url_object,
+    stream_download_to_file,
     validate_upload_url,
-    verify_downloaded_file,
 )
 
 logger = getLogger()
@@ -107,6 +110,11 @@ class Asset(BaseAsset):
         required=False,
         description="Maximum number of entries in cache. Values of zero or less will not limit size and decimal value will be converted to floor value (Default: 1000)",
         default=1000.0,
+    )
+    max_file_download_size_mib: float = AssetField(
+        required=False,
+        description="Maximum size in MiB for a file downloaded by the get file action (Default: 100 MiB)",
+        default=100.0,
     )
 
     def get_client(self) -> httpx.Client:
@@ -594,23 +602,43 @@ class GetFileParams(Params):
 @app.action(
     description="Downloads a file from VirusTotal and adds it to the vault",
     action_type="investigate",
+    verbose="<b>get file</b> streams the requested file into the vault and verifies its requested hash before it is added. Downloads larger than the asset's maximum file download size are rejected; the default limit is 100 MiB.",
     render_as="table",
 )
 def get_file(params: GetFileParams, soar: SOARClient, asset: Asset) -> ActionOutput:
-    client = asset.get_client()
-    _check_rate_limit(asset)
-    response = client.get(f"files/{encode_api_path_segment(params.hash)}/download")
-    if asset.rate_limit:
-        asset.cache_state["rate_limit_timestamps"].append(
-            response.headers.get("Date", time.time())
+    try:
+        max_bytes = int(asset.max_file_download_size_mib * 1024 * 1024)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise AssetMisconfiguration(
+            "Maximum file download size must be a positive number"
+        ) from exc
+    if max_bytes <= 0:
+        raise AssetMisconfiguration(
+            "Maximum file download size must be greater than zero"
         )
 
-    response.raise_for_status()
-    verify_downloaded_file(params.hash, response.content)
+    client = asset.get_client()
+    _check_rate_limit(asset)
+    vault_temp_dir = Path(soar.vault.get_vault_tmp_dir())
+    download_dir = Path(tempfile.mkdtemp(prefix="virustotalv3-", dir=vault_temp_dir))
+    download_path = download_dir / "download"
 
-    soar.vault.create_attachment(
-        soar.get_executing_container_id(), response.content, params.hash
-    )
+    try:
+        with client.stream(
+            "GET", f"files/{encode_api_path_segment(params.hash)}/download"
+        ) as response:
+            if asset.rate_limit:
+                asset.cache_state["rate_limit_timestamps"].append(
+                    response.headers.get("Date", time.time())
+                )
+            response.raise_for_status()
+            stream_download_to_file(response, download_path, params.hash, max_bytes)
+
+        soar.vault.add_attachment(
+            soar.get_executing_container_id(), str(download_path), params.hash
+        )
+    finally:
+        shutil.rmtree(download_dir, ignore_errors=True)
 
     soar.set_message("File downloaded and added to the vault.")
     return ActionOutput()

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import hashlib
+from pathlib import Path
 from urllib.parse import quote, urlsplit
 
 from soar_sdk.exceptions import ActionFailure
@@ -25,6 +26,7 @@ SENSITIVE_RESPONSE_HEADERS = {
     "set-cookie",
     "www-authenticate",
 }
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 
 
 def encode_api_path_segment(value: str) -> str:
@@ -67,8 +69,8 @@ def sanitize_url_object(data: dict) -> dict:
     return data
 
 
-def verify_downloaded_file(file_hash: str, content: bytes) -> None:
-    """Fail closed unless downloaded bytes match the requested content digest."""
+def _get_hash_details(file_hash: str) -> tuple[str, str]:
+    """Return the normalized expected digest and its supported algorithm."""
     normalized_hash = file_hash.strip().lower()
     algorithm = {32: "md5", 40: "sha1", 64: "sha256"}.get(len(normalized_hash))
     if algorithm is None or any(
@@ -76,11 +78,62 @@ def verify_downloaded_file(file_hash: str, content: bytes) -> None:
     ):
         raise ActionFailure("File hash must be an MD5, SHA-1, or SHA-256 digest")
 
-    computed_hash = hashlib.new(algorithm, content, usedforsecurity=False).hexdigest()
-    if computed_hash != normalized_hash:
+    return normalized_hash, algorithm
+
+
+def verify_downloaded_file_digest(file_hash: str, actual_hash: str) -> None:
+    """Fail closed unless a downloaded file digest matches the requested digest."""
+    normalized_hash, _algorithm = _get_hash_details(file_hash)
+    if actual_hash != normalized_hash:
         raise ActionFailure(
             "Downloaded file content does not match the requested hash; refusing to vault it"
         )
+
+
+def verify_downloaded_file(file_hash: str, content: bytes) -> None:
+    """Fail closed unless downloaded bytes match the requested content digest."""
+    normalized_hash, algorithm = _get_hash_details(file_hash)
+
+    computed_hash = hashlib.new(algorithm, content, usedforsecurity=False).hexdigest()
+    verify_downloaded_file_digest(normalized_hash, computed_hash)
+
+
+def stream_download_to_file(
+    response, file_path: Path, file_hash: str, max_bytes: int
+) -> int:
+    """Stream a download to disk while enforcing advertised and observed size limits."""
+    if max_bytes <= 0:
+        raise ActionFailure("Maximum file download size must be greater than zero")
+
+    advertised_size = response.headers.get("Content-Length")
+    if advertised_size is not None:
+        try:
+            advertised_bytes = int(advertised_size)
+        except (TypeError, ValueError) as exc:
+            raise ActionFailure(
+                "VirusTotal returned an invalid Content-Length"
+            ) from exc
+        if advertised_bytes < 0 or advertised_bytes > max_bytes:
+            raise ActionFailure(
+                "VirusTotal file exceeds the configured maximum download size"
+            )
+
+    _normalized_hash, algorithm = _get_hash_details(file_hash)
+    hasher = hashlib.new(algorithm, usedforsecurity=False)
+    observed_bytes = 0
+
+    with file_path.open("wb") as file_handle:
+        for chunk in response.iter_bytes(chunk_size=DOWNLOAD_CHUNK_SIZE):
+            observed_bytes += len(chunk)
+            if observed_bytes > max_bytes:
+                raise ActionFailure(
+                    "VirusTotal file exceeds the configured maximum download size"
+                )
+            file_handle.write(chunk)
+            hasher.update(chunk)
+
+    verify_downloaded_file_digest(file_hash, hasher.hexdigest())
+    return observed_bytes
 
 
 def sanitize_key_names(data: dict) -> dict:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import hashlib
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from soar_sdk.exceptions import ActionFailure
 
-from app import GetFileParams, get_file
+import app
+from app import DetonateFileParams, DetonateUrlParams, GetFileParams, get_file
 from utils import (
     encode_api_path_segment,
     sanitize_url_object,
@@ -159,6 +162,60 @@ class DownloadAsset:
         return DownloadClient(self.response)
 
 
+class DetonationAsset:
+    poll_interval = 1
+    waiting_time = 0
+
+
+class DetonationSoar:
+    def __init__(self, attachments=None):
+        self.vault = SimpleNamespace(get_attachment=lambda **_kwargs: attachments or [])
+
+    def set_summary(self, _summary) -> None:
+        return None
+
+    def set_message(self, _message: str) -> None:
+        return None
+
+
+class StopPolling(Exception):
+    pass
+
+
+class JsonResponse:
+    def __init__(self):
+        self.headers = {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return {"data": {"id": "response"}}
+
+
+class RequestClient:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method: str, endpoint: str, **kwargs) -> JsonResponse:
+        self.calls.append((method, endpoint, kwargs))
+        return JsonResponse()
+
+
+class CacheAsset:
+    cache_reputation_checks = True
+    cache_expiration_interval = 3600
+    cache_size = 10
+    rate_limit = False
+
+    def __init__(self):
+        self.client = RequestClient()
+        self.cache_state = {"rate_limit_timestamps": []}
+
+    def get_client(self) -> RequestClient:
+        return self.client
+
+
 def test_stream_download_to_file_enforces_advertised_size(tmp_path: Path):
     digest = hashlib.sha256(b"small").hexdigest()
     response = StreamResponse([b"small"], content_length="6")
@@ -201,3 +258,110 @@ def test_get_file_streams_to_vault_temp_and_removes_temp_dir(tmp_path: Path):
     assert soar.vault.attachment_content == content
     assert soar.message == "File downloaded and added to the vault."
     assert list(tmp_path.iterdir()) == []
+
+
+def test_non_get_requests_are_never_cached():
+    asset = CacheAsset()
+
+    app._make_request(asset, "POST", "urls", data={"url": "https://example.com"})
+
+    assert asset.client.calls == [
+        ("POST", "urls", {"data": {"url": "https://example.com"}})
+    ]
+    assert "vt_cache" not in asset.cache_state
+
+
+def test_detonate_url_reanalyzes_known_url_and_polls_returned_id(monkeypatch):
+    calls = []
+    url_id = base64.urlsafe_b64encode(b"https://example.com").decode().strip("=")
+
+    def make_request(*args, **kwargs):
+        calls.append((args[1], args[2], kwargs))
+        return {"data": {"id": "known-url" if len(calls) == 1 else "analysis-url"}}
+
+    def stop_polling(scan_id, *_args):
+        assert scan_id == "analysis-url"
+        raise StopPolling
+
+    monkeypatch.setattr(app, "_make_request", make_request)
+    monkeypatch.setattr(app, "poll_for_result", stop_polling)
+
+    with pytest.raises(StopPolling):
+        app.detonate_url.__wrapped__(
+            DetonateUrlParams(url="https://example.com"),
+            DetonationSoar(),
+            DetonationAsset(),
+        )
+
+    assert calls == [
+        (
+            "GET",
+            f"urls/{url_id}",
+            {"raise_for_status": False, "cacheable": False},
+        ),
+        (
+            "POST",
+            f"urls/{url_id}/analyse",
+            {},
+        ),
+    ]
+
+
+def test_detonate_url_submits_unknown_url_and_polls_returned_id(monkeypatch):
+    calls = []
+
+    def make_request(*args, **kwargs):
+        calls.append((args[1], args[2], kwargs))
+        if len(calls) == 1:
+            return {"error": {"code": "NotFoundError"}}
+        return {"data": {"id": "submitted-url"}}
+
+    def stop_polling(scan_id, *_args):
+        assert scan_id == "submitted-url"
+        raise StopPolling
+
+    monkeypatch.setattr(app, "_make_request", make_request)
+    monkeypatch.setattr(app, "poll_for_result", stop_polling)
+
+    with pytest.raises(StopPolling):
+        app.detonate_url.__wrapped__(
+            DetonateUrlParams(url="https://example.com"),
+            DetonationSoar(),
+            DetonationAsset(),
+        )
+
+    assert calls[1] == ("POST", "urls", {"data": {"url": "https://example.com"}})
+
+
+def test_detonate_file_reanalyzes_known_file_and_polls_returned_id(monkeypatch):
+    file_hash = "a" * 64
+    attachment = SimpleNamespace(name="sample", path="unused", hash=file_hash, size=1)
+    calls = []
+
+    def make_request(*args, **kwargs):
+        calls.append((args[1], args[2], kwargs))
+        return {"data": {"id": "known-file" if len(calls) == 1 else "analysis-file"}}
+
+    def stop_polling(scan_id, *_args):
+        assert scan_id == "analysis-file"
+        raise StopPolling
+
+    monkeypatch.setattr(app, "_make_request", make_request)
+    monkeypatch.setattr(app, "poll_for_result", stop_polling)
+
+    with pytest.raises(StopPolling):
+        app.detonate_file.__wrapped__(
+            DetonateFileParams(vault_id="vault-id"),
+            DetonationSoar([attachment]),
+            DetonationAsset(),
+        )
+
+    assert calls == [
+        ("GET", f"files/{file_hash}", {"raise_for_status": False, "cacheable": False}),
+        ("POST", f"files/{file_hash}/analyse", {}),
+    ]
+
+
+def test_detonate_actions_are_not_read_only():
+    assert app.detonate_url.meta.read_only is False
+    assert app.detonate_file.meta.read_only is False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import hashlib
+from pathlib import Path
 
 import pytest
 from soar_sdk.exceptions import ActionFailure
 
+from app import GetFileParams, get_file
 from utils import (
     encode_api_path_segment,
     sanitize_url_object,
+    stream_download_to_file,
     validate_upload_url,
     verify_downloaded_file,
 )
@@ -79,3 +82,122 @@ def test_verify_downloaded_file_rejects_mismatched_content():
     digest = hashlib.sha256(b"expected").hexdigest()
     with pytest.raises(ActionFailure, match="does not match"):
         verify_downloaded_file(digest, b"substituted")
+
+
+class StreamResponse:
+    def __init__(self, chunks: list[bytes], content_length: str | None = None):
+        self.chunks = chunks
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = content_length
+
+    def iter_bytes(self, chunk_size: int):
+        assert chunk_size > 0
+        yield from self.chunks
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class StreamContext:
+    def __init__(self, response: StreamResponse):
+        self.response = response
+
+    def __enter__(self) -> StreamResponse:
+        return self.response
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+
+class DownloadClient:
+    def __init__(self, response: StreamResponse):
+        self.response = response
+
+    def stream(self, method: str, endpoint: str) -> StreamContext:
+        assert method == "GET"
+        assert endpoint.endswith("/download")
+        return StreamContext(self.response)
+
+
+class DownloadVault:
+    def __init__(self, temp_dir: Path):
+        self.temp_dir = temp_dir
+        self.attachment_content = None
+
+    def get_vault_tmp_dir(self) -> str:
+        return str(self.temp_dir)
+
+    def add_attachment(
+        self, _container_id: int, file_path: str, _file_name: str
+    ) -> str:
+        self.attachment_content = Path(file_path).read_bytes()
+        return "vault-id"
+
+
+class DownloadSoar:
+    def __init__(self, temp_dir: Path):
+        self.vault = DownloadVault(temp_dir)
+        self.message = None
+
+    def get_executing_container_id(self) -> int:
+        return 1
+
+    def set_message(self, message: str) -> None:
+        self.message = message
+
+
+class DownloadAsset:
+    rate_limit = False
+    max_file_download_size_mib = 100.0
+
+    def __init__(self, response: StreamResponse):
+        self.response = response
+        self.cache_state = {}
+
+    def get_client(self) -> DownloadClient:
+        return DownloadClient(self.response)
+
+
+def test_stream_download_to_file_enforces_advertised_size(tmp_path: Path):
+    digest = hashlib.sha256(b"small").hexdigest()
+    response = StreamResponse([b"small"], content_length="6")
+
+    with pytest.raises(ActionFailure, match="maximum download size"):
+        stream_download_to_file(response, tmp_path / "download", digest, max_bytes=5)
+
+
+def test_stream_download_to_file_enforces_observed_size(tmp_path: Path):
+    content = b"too-large"
+    digest = hashlib.sha256(content).hexdigest()
+    response = StreamResponse([b"too-", b"large"], content_length="1")
+
+    with pytest.raises(ActionFailure, match="maximum download size"):
+        stream_download_to_file(response, tmp_path / "download", digest, max_bytes=5)
+
+
+def test_stream_download_to_file_writes_verified_content(tmp_path: Path):
+    content = b"streamed sample"
+    digest = hashlib.sha256(content).hexdigest()
+    destination = tmp_path / "download"
+    response = StreamResponse(
+        [b"streamed ", b"sample"], content_length=str(len(content))
+    )
+
+    assert stream_download_to_file(
+        response, destination, digest, max_bytes=1024
+    ) == len(content)
+    assert destination.read_bytes() == content
+
+
+def test_get_file_streams_to_vault_temp_and_removes_temp_dir(tmp_path: Path):
+    content = b"streamed sample"
+    digest = hashlib.sha256(content).hexdigest()
+    soar = DownloadSoar(tmp_path)
+    asset = DownloadAsset(StreamResponse([content], content_length=str(len(content))))
+
+    get_file.__wrapped__(GetFileParams(hash=digest), soar, asset)
+
+    assert soar.vault.attachment_content == content
+    assert soar.message == "File downloaded and added to the vault."
+    assert list(tmp_path.iterdir()) == []

--- a/uv.lock
+++ b/uv.lock
@@ -49,7 +49,7 @@ name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -61,8 +61,8 @@ name = "authlib"
 version = "1.7.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "joserfc", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
+    { name = "joserfc" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
@@ -74,8 +74,8 @@ name = "beautifulsoup4"
 version = "4.13.5"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "soupsieve", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
 wheels = [
@@ -87,7 +87,7 @@ name = "bleach"
 version = "6.3.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "webencodings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "webencodings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
 wheels = [
@@ -99,8 +99,8 @@ name = "build"
 version = "1.4.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyproject-hooks", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
 wheels = [
@@ -121,7 +121,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "(implementation_name != 'PyPy' and platform_machine == 'arm64' and sys_platform == 'darwin') or (implementation_name != 'PyPy' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (implementation_name != 'PyPy' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name != 'PyPy' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -252,7 +252,7 @@ name = "cryptography"
 version = "47.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
 wheels = [
@@ -331,13 +331,13 @@ name = "extract-msg"
 version = "0.55.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "compressed-rtf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ebcdic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "olefile", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "red-black-tree-mod", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rtfde", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tzlocal", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "beautifulsoup4" },
+    { name = "compressed-rtf" },
+    { name = "ebcdic" },
+    { name = "olefile" },
+    { name = "red-black-tree-mod" },
+    { name = "rtfde" },
+    { name = "tzlocal" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/65/c70afb3b119a44b3ee36b029485dc15326cf3a7c50da19a1ecbbf949c5d1/extract_msg-0.55.0.tar.gz", hash = "sha256:cf08283498c3dfcc7f894dad1579f52e3ced9fb76b865c2355cbe757af8a54e1", size = 331170, upload-time = "2025-08-12T16:07:56.537Z" }
 wheels = [
@@ -367,10 +367,10 @@ name = "hatchling"
 version = "1.29.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pathspec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pluggy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "trove-classifiers", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/9c/b4cfe330cd4f49cff17fd771154730555fa4123beb7f292cf0098b4e6c20/hatchling-1.29.0.tar.gz", hash = "sha256:793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6", size = 55656, upload-time = "2026-02-23T19:42:06.539Z" }
 wheels = [
@@ -382,8 +382,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "h11", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -395,10 +395,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpcore", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -410,7 +410,7 @@ name = "httpx-retries"
 version = "0.5.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fb/f5/046cac13877ce9b55aebdbb3999e0e45b19b989a95c5fd1040fa04bd1f92/httpx_retries-0.5.0.tar.gz", hash = "sha256:d8c8e1e0852d84be3837aba0bcf78aeb89a4b77db95e8cc988c8c058830b3044", size = 15647, upload-time = "2026-04-20T01:21:47.154Z" }
 wheels = [
@@ -458,7 +458,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -470,7 +470,7 @@ name = "joserfc"
 version = "1.6.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
 wheels = [
@@ -517,7 +517,7 @@ name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -570,8 +570,8 @@ name = "msoffcrypto-tool"
 version = "6.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "olefile", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
+    { name = "olefile" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/34/6250bdddaeaae24098e45449ea362fb3555a65fba30cad0ad5630ea48d1a/msoffcrypto_tool-6.0.0.tar.gz", hash = "sha256:9a5ebc4c0096b42e5d7ebc2350afdc92dc511061e935ca188468094fdd032bbe", size = 40593, upload-time = "2026-01-12T08:59:56.73Z" }
 wheels = [
@@ -583,10 +583,10 @@ name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "librt", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
-    { name = "mypy-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pathspec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
@@ -640,12 +640,12 @@ name = "oletools"
 version = "0.60.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "colorclass", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "easygui", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "msoffcrypto-tool", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "olefile", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pcodedmp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyparsing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "colorclass" },
+    { name = "easygui" },
+    { name = "msoffcrypto-tool", marker = "platform_python_implementation != 'PyPy' or sys_platform == 'linux'" },
+    { name = "olefile" },
+    { name = "pcodedmp" },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/2f/037f40e44706d542b94a2312ccc33ee2701ebfc9a83b46b55263d49ce55a/oletools-0.60.2.zip", hash = "sha256:ad452099f4695ffd8855113f453348200d195ee9fa341a09e197d66ee7e0b2c3", size = 3433750, upload-time = "2024-07-02T14:50:38.242Z" }
 wheels = [
@@ -675,7 +675,7 @@ name = "pcodedmp"
 version = "1.2.6"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "oletools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "oletools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/20/6d461e29135f474408d0d7f95b2456a9ba245560768ee51b788af10f7429/pcodedmp-1.2.6.tar.gz", hash = "sha256:025f8c809a126f45a082ffa820893e6a8d990d9d7ddb68694b5a9f0a6dbcd955", size = 35549, upload-time = "2019-07-30T18:05:42.516Z" }
 wheels = [
@@ -687,7 +687,7 @@ name = "pip-licenses"
 version = "5.5.5"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "prettytable", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prettytable" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/18/ddd93af610a04f56a51a27095ddfe55238e1ec236f6758730a0d2c0b49f2/pip_licenses-5.5.5.tar.gz", hash = "sha256:60750c006adf7a0910347b726e8ee9fee3bc8d2e7c8307a5c4ec0776c8e2a276", size = 54955, upload-time = "2026-03-28T22:12:56.48Z" }
 wheels = [
@@ -717,11 +717,11 @@ name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cfgv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "identify", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nodeenv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "virtualenv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
@@ -733,7 +733,7 @@ name = "prettytable"
 version = "3.17.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "wcwidth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "wcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
@@ -754,10 +754,10 @@ name = "pydantic"
 version = "2.13.3"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "annotated-types", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
 wheels = [
@@ -769,7 +769,7 @@ name = "pydantic-core"
 version = "2.46.3"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
 wheels = [
@@ -813,7 +813,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -839,9 +839,9 @@ name = "pytest"
 version = "7.4.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "iniconfig", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pluggy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
 wheels = [
@@ -853,7 +853,7 @@ name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
@@ -865,10 +865,10 @@ name = "pytest-watch"
 version = "4.2.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "docopt", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "watchdog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "colorama" },
+    { name = "docopt" },
+    { name = "pytest" },
+    { name = "watchdog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/47/ab65fc1d682befc318c439940f81a0de1026048479f732e84fe714cd69c0/pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9", size = 16340, upload-time = "2018-05-20T19:52:16.194Z" }
 
@@ -877,8 +877,8 @@ name = "python-discovery"
 version = "1.2.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "filelock" },
+    { name = "platformdirs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
 wheels = [
@@ -922,10 +922,10 @@ name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "charset-normalizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "urllib3", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
@@ -937,8 +937,8 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
@@ -950,8 +950,8 @@ name = "rtfde"
 version = "0.1.2.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "lark", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "oletools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "lark" },
+    { name = "oletools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/5c/116a016b38af589e8141160bc9b034b73dde2e50c22a921751f4d982a7ca/rtfde-0.1.2.2.tar.gz", hash = "sha256:2f0cd6ecd644071e39452e6fc4f4a1435453af0ec7c90ea86fb4fc96010c7f1b", size = 33408, upload-time = "2025-12-09T17:10:31.805Z" }
 wheels = [
@@ -1004,27 +1004,27 @@ name = "splunk-soar-sdk"
 version = "3.25.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "authlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "beautifulsoup4", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "bleach", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "build", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "distro", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "extract-msg", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "hatchling", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx-retries", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "humanize", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pip-licenses", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "setuptools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "toml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "authlib" },
+    { name = "beautifulsoup4" },
+    { name = "bleach" },
+    { name = "build" },
+    { name = "click" },
+    { name = "distro" },
+    { name = "extract-msg" },
+    { name = "hatchling" },
+    { name = "httpx" },
+    { name = "httpx-retries" },
+    { name = "humanize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pip-licenses" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "toml" },
+    { name = "tqdm" },
+    { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/35/986d8a105d7e60844c1f90994841510720778970e04830aa43690335b739/splunk_soar_sdk-3.25.1.tar.gz", hash = "sha256:e4e0b39f8f26773e4414cccfc942a1cd3febcd1a3ee2bcae934986fc8bd2a2f1", size = 738622, upload-time = "2026-06-22T19:26:46.652Z" }
 wheels = [
@@ -1063,10 +1063,10 @@ name = "typer"
 version = "0.23.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "shellingham", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
 wheels = [
@@ -1087,7 +1087,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -1117,10 +1117,10 @@ name = "virtualenv"
 version = "21.3.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "distlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "filelock", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-discovery", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
@@ -1129,22 +1129,22 @@ wheels = [
 
 [[package]]
 name = "virustotalv3"
-version = "3.0.4"
+version = "3.0.5"
 source = { virtual = "." }
 dependencies = [
-    { name = "splunk-soar-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "splunk-soar-sdk" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "coverage", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "mypy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pre-commit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest-mock", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest-watch", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ruff", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "splunk-soar-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "coverage" },
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-mock" },
+    { name = "pytest-watch" },
+    { name = "ruff" },
+    { name = "splunk-soar-sdk" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary

- Stream `get file` downloads into a vault temporary directory with a configurable 100 MiB default limit, Content-Length and observed-byte enforcement, digest verification, and guaranteed cleanup.
- Request a fresh VirusTotal analysis for known URL and file detonation inputs, while preserving submit/upload behavior for unknown inputs and polling the returned analysis ID.
- Disable response caching for detonation/reanalysis and every non-GET request; mark both detonation actions as non-read-only and update generated action documentation.

## Tracking

- [PAPP-38306](https://splunk.atlassian.net/browse/PAPP-38306)
- [PSAAS-33167](https://splunk.atlassian.net/browse/PSAAS-33167)
- [PSAAS-33270](https://splunk.atlassian.net/browse/PSAAS-33270)
- ESPM-5228

## Validation

- `uv run --frozen pytest -q` — 20 passed.
- `pre-commit autoupdate` followed by `pre-commit run --all-files`.
- Checked commit signatures and `git diff --check` against `origin/main`.

Written by Codex.
